### PR TITLE
fix: restore copy fallback for non-HTTPS environments

### DIFF
--- a/src/js/__tests__/components.test.js
+++ b/src/js/__tests__/components.test.js
@@ -58,8 +58,26 @@ describe('CloneCommands', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
   });
 
-  it('should show error toast when clipboard API fails', async () => {
+  it('should fallback to execCommand when clipboard API fails', async () => {
     navigator.clipboard.writeText = vi.fn().mockRejectedValue(new Error('fail'));
+    document.execCommand = vi.fn().mockReturnValue(true);
+    
+    const element = createCloneCommands('owner/repo');
+    document.body.appendChild(element);
+    const copyBtn = element.querySelector('.clone-commands__copy');
+    
+    copyBtn.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    const toast = document.querySelector('.toast');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toContain('Copied to clipboard');
+  });
+
+  it('should show error toast when both clipboard API and execCommand fail', async () => {
+    navigator.clipboard.writeText = vi.fn().mockRejectedValue(new Error('fail'));
+    document.execCommand = vi.fn().mockReturnValue(false);
     
     const element = createCloneCommands('owner/repo');
     document.body.appendChild(element);

--- a/src/js/components/CloneCommands.js
+++ b/src/js/components/CloneCommands.js
@@ -53,7 +53,19 @@ export const createCloneCommands = (fullName, hasDevContainer = false) => {
       await navigator.clipboard.writeText(input.value);
       showToast('Copied to clipboard', 'success');
     } catch {
-      showToast('Failed to copy - please copy manually', 'error');
+      // Fallback for file://, HTTP, or browsers without Clipboard API
+      try {
+        input.select();
+        input.setSelectionRange(0, 99999); // Mobile support
+        const success = document.execCommand('copy');
+        if (success) {
+          showToast('Copied to clipboard', 'success');
+        } else {
+          throw new Error('execCommand returned false');
+        }
+      } catch {
+        showToast('Failed to copy - please copy manually', 'error');
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Restores `document.execCommand('copy')` fallback when Clipboard API fails
- Fixes regression from PR #7 that broke copy for `file://`, HTTP, and older browsers

## Problem

PR #7 removed the execCommand fallback entirely, breaking copy functionality for users in environments where `navigator.clipboard` is unavailable:
- `file://` protocol (local development)
- Non-HTTPS hosting (HTTP sites)
- Older browsers without Clipboard API

## Solution

Implement intelligent fallback:
1. Try `navigator.clipboard.writeText()` first (modern, secure)
2. If that fails, try `document.execCommand('copy')` (legacy fallback)
3. Only show error toast if both methods fail

## Changes

- `src/js/components/CloneCommands.js`: Restored execCommand fallback with mobile support
- `src/js/__tests__/components.test.js`: Updated tests to verify fallback behavior

## Testing

- ✅ 241 tests passing
- Fallback behavior verified in test environment